### PR TITLE
refactor: change router implementation to lua-radix-router for better performance

### DIFF
--- a/lualib/web/context_web.lua
+++ b/lualib/web/context_web.lua
@@ -14,6 +14,8 @@ local mt = { __index = M,__close = function(t)
 	table_pool:release(t)
 end}
 
+local req_ctx = {}
+
 function M:new(app, oldreq)
     local req = request:new(oldreq)
     if not req then
@@ -22,7 +24,9 @@ function M:new(app, oldreq)
 
     local res = response:new()
 
-    local handlers, params = app.router:match(req.path, req.method)
+    req_ctx.method = req.method
+    local params = {}
+    local handlers = app.router:match(req.path, req_ctx, params)
 
     local found = false
     if handlers then


### PR DESCRIPTION
**Summary**

The rax based router is not efficient when it comes to the URL scenario. Only the partial path(before the first `:`) is stored in radix tree, which means it may become a linear search in the worst scenario.
See https://github.com/hanxi/lua-rax/blob/7c80520074c35d1afb99fc4698f6684c9575393d/rax.lua#L75. 

Based on the benchamrks, the lua-radix-router is ~70x faster than rax based router in the GitHub API test suit. See [benchmarks](https://github.com/vm-001/lua-radix-router?tab=readme-ov-file#-benchmarks)