### PR TITLE
1.不需要chmod -R,只是单个文件没有可执行权限

### DIFF
--- a/install_centos.sh
+++ b/install_centos.sh
@@ -8,7 +8,7 @@ install_dependencies() {
 
 # 安装Perl
 install_perl() {
-	chmod -R 744 "3rd/perl"
+	chmod 744 "3rd/perl/Configure"
 	cd "3rd/perl" || exit
 	(
 		source /opt/rh/devtoolset-9/enable
@@ -43,7 +43,7 @@ install_openssl() {
 	# 获取脚本当前目录
 	CURRENT_DIR="$(dirname "$BASH_SOURCE")"
 	ABSOLUTE_PATH="$(realpath "$CURRENT_DIR/3rd/openssl")"
-	chmod -R 744 "3rd/openssl"
+	#chmod -R 744 "3rd/openssl"
 	cd "3rd/openssl" || exit
 	(
 		rm -f *.a
@@ -72,7 +72,7 @@ install_openssl() {
 
 # 编译zlib-1.3.1
 install_zlib() {
-	chmod -R 744 "3rd/zlib"
+	#chmod -R 744 "3rd/zlib"
 	cd "3rd/zlib" || exit
 	(
 		rm -f *.o libz.*


### PR DESCRIPTION
在docker里面执行install_centos.sh的时候，chmod +R 命令行会卡在那里一直不动，发现只是单个文件没有可执行权限，故修改