### PR TITLE
Fix cmake build error: 3rd/lua-protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     target_link_libraries(frpcpack liblua)
 
     # 生成动态库 pb.so
-    aux_source_directory(3rd/lua-protobuf-0.4.0 PB_SRC)
+    aux_source_directory(3rd/lua-protobuf PB_SRC)
     add_library(pb SHARED ${PB_SRC})
     target_link_libraries(pb liblua)
 


### PR DESCRIPTION
Before:
CMakelists.txt
Line 155:
aux_source_directory(3rd/lua-protobuf-0.4.0 PB_SRC)

After:
aux_source_directory(3rd/lua-protobuf PB_SRC)

In fact, the version of lua-protobuf within the project is already [lua-protobuf更新到0.5.3](https://github.com/huahua132/skynet_fly/commit/082a90490a08134f19e2a7701c9e956c0808fc44)